### PR TITLE
Fix inventory price display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2 hotfix
+
+- Fix inventory RMB price display
+
 ## 1.1
 
 - Add original RMB list price on inspect page & underneath listings

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Buff Currency Converter",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Change the listing currency on 163.buff.com",
   "permissions": [
     "alarms",

--- a/src/content.js
+++ b/src/content.js
@@ -43,7 +43,6 @@ function convertCurrencyInElement(element) {
       convertCurrencyInElement(child);
     }
   }
-
   // Find and convert RMB prices to the selected currency
   const reg = /¥ (\d+(.\d+)?)/gm;
   if (reg.test(element.textContent)) {
@@ -59,7 +58,14 @@ function convertCurrencyInElement(element) {
       const originalPriceStr = RMBPrice.toFixed(2).replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
 
       // Add OG price to market listings
-      const isMarketList = element.closest('.detail-tab-cont');
+      const isMarketList = element.closest('.detail-tab-cont') && window.location.href.startsWith("https://buff.163.com/goods/");
+
+      // Add OG price to inventory listings
+      const isInventoryList = element.closest('.detail-tab-cont') && !window.location.href.startsWith("https://buff.163.com/goods/");
+
+      // Add smaller OG price to inspect page
+      const isInspectBottom = element.closest('.inspect-bottom');
+
       if (isMarketList) {
         const priceElement = document.createElement('p');
         priceElement.style.fontSize = '0.95em';
@@ -68,8 +74,17 @@ function convertCurrencyInElement(element) {
         element.after(priceElement);
       }
 
-      // Add smaller OG price to inspect page
-      const isInspectBottom = element.closest('.inspect-bottom');
+      if (isInventoryList) {
+        const priceElement = document.createElement('small');
+        priceElement.style.fontSize = '1em';
+        priceElement.style.paddingLeft = '0.5em';
+        priceElement.style.color = 'gray';
+        priceElement.textContent = `(¥${originalPriceStr})`;
+
+        const parentElement = element.parentElement;
+        parentElement.insertBefore(priceElement, element.nextSibling);
+      }
+
       if (isInspectBottom) {
         const priceElement = document.createElement('p');
         priceElement.style.fontSize = '1em';


### PR DESCRIPTION
In the last change, original RMB prices were added to market & inspect views. 



### This broke the inventory view:
![image](https://user-images.githubusercontent.com/53287407/234726382-246025b3-35a5-4e59-8a1e-d26d4acd810f.png)


### With the fix
![image](https://user-images.githubusercontent.com/53287407/234726241-fea7c42f-44e9-4da2-85df-18ef32c6e205.png)
